### PR TITLE
add 5 seconds sleep between getting EPG from SK source

### DIFF
--- a/epg2xml-web.php
+++ b/epg2xml-web.php
@@ -402,8 +402,10 @@ function getEPG() {
         elseif($ChannelSource == 'LG') :
             GetEPGFromLG($ChannelInfo);
         elseif($ChannelSource == 'SK') :
+            sleep(5);
             GetEPGFromSK($ChannelInfo);
         elseif($ChannelSource == 'SKB') :
+            sleep(5);
             GetEPGFromSKB($ChannelInfo);
         elseif($ChannelSource == 'NAVER') :
             GetEPGFromNaver($ChannelInfo);
@@ -636,8 +638,8 @@ function GetEPGFromSKB($ChannelInfo) {
             if ($response === False && $GLOBALS['debug']) :
                 printError($ChannelName.HTTP_ERROR);
             else :
-		$response = str_replace('charset="EUC-KR"', 'charset="UTF-8"', $response);
-		$response = mb_convert_encoding($response, "UTF-8", "EUC-KR");
+                $response = str_replace('charset="EUC-KR"', 'charset="UTF-8"', $response);
+                $response = mb_convert_encoding($response, "UTF-8", "EUC-KR");
                 $response = preg_replace('/<!--(.*?)-->/is', '', $response);
                 $response = preg_replace('/<span class="round_flag flag02">(.*?)<\/span>/', '', $response);
                 $response = preg_replace('/<span class="round_flag flag03">(.*?)<\/span>/', '', $response);
@@ -647,8 +649,8 @@ function GetEPGFromSKB($ChannelInfo) {
                 $response = preg_replace('/<span class="round_flag flag11">(.*?)<\/span>/', '', $response);
                 $response = preg_replace('/<span class="round_flag flag12">(.*?)<\/span>/', '', $response);
                 $response = preg_replace('/<strong class="hide">프로그램 안내<\/strong>/', '', $response);
-		$response = preg_replace_callback('/<p class="cont">(.*)/', 'converthtmlspecialchars', $response);
-		$response = preg_replace_callback('/<p class="tit">(.*)/', 'converthtmlspecialchars', $response);
+                $response = preg_replace_callback('/<p class="cont">(.*)/', 'converthtmlspecialchars', $response);
+                $response = preg_replace_callback('/<p class="tit">(.*)/', 'converthtmlspecialchars', $response);
                 $dom = new DomDocument;
                 libxml_use_internal_errors(True);
                 if($dom->loadHTML('<?xml encoding="utf-8" ?>'.$response)):
@@ -675,7 +677,7 @@ function GetEPGFromSKB($ChannelInfo) {
                             if(isset($matches[5])) $subprogramName = trim($matches[5]) ?: "";
                             if(isset($matches[3])) $episode = $matches[3] ?: "";
                             if(isset($matches[7])) $rebroadcast = $matches[7] ? True : False;
-						endif;
+                        endif;
                         if(trim($cells->item(1)->childNodes->item(1)->nodeValue)) $rating = str_replace('세 이상', '', trim($cells->item(1)->childNodes->item(1)->nodeValue))  ?: 0;
                         //ChannelId, startTime, programName, subprogramName, desc, actors, producers, category, episode, rebroadcast, rating
                         $epginfo[] = array($ChannelId, $startTime, $programName, $subprogramName, $desc, $actors, $producers, $category, $episode, $rebroadcast, $rating);
@@ -952,7 +954,7 @@ function startsWith($haystack, $needle) {
 }
 
 function converthtmlspecialchars($match) {
-	return '<p class="cont">'.htmlspecialchars($match[1]);
+    return '<p class="cont">'.htmlspecialchars($match[1]);
 }
 
 //사용방법


### PR DESCRIPTION
최근 SK 소스로부터 EPG 정보를 빠르게 얻어오는 경우 중간에 block되어 응답을 주지 않는 현상이 발생하고 있습니다.
이 현상을 방지하기 위해 SK, SKB 소스로부터 EPG를 얻어올 때 5초 씩의 간격을 두고 받아오도록 수정했습니다.
전체적으로 EPG를 받아오는데 걸리는 시간이 채널 수가 많을 경우 몇 분 정도 길어지게 되긴 합니다만, 주로 epg2xml이 백그라운드 배치 작업으로 수행되는 작업이기 때문에 크게 문제가 되지는 않을 듯 합니다.

추가로, 이 작업을 하면서 indentation이 tab으로 되어 있는 몇 줄의 코드를 모두 space로 통일시켰습니다.